### PR TITLE
Spell list

### DIFF
--- a/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
@@ -53,11 +53,11 @@ public abstract class InteractiveAimingItem implements InteractiveItem {
         }
         Entity entityShooter = (Entity) shooter;
         if(entityShooter.getUniqueId().equals(holder.getUUID()) && arrowID == null) {
-            launched(projectile, entityShooter);
+            launched(projectile);
         }
     }
 
-    private void launched(Projectile projectile, Entity shooter) {
+    private void launched(Projectile projectile) {
         this.world = projectile.getWorld();
         this.arrowID = projectile.getUniqueId();
         ready = false;

--- a/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
@@ -3,9 +3,12 @@ package net.akami.yggdrasil.api.item;
 import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.game.task.GameItemClock;
 import net.akami.yggdrasil.api.input.UUIDHolder;
+import net.akami.yggdrasil.api.utils.ItemUtils;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.entity.projectile.Projectile;
 import org.spongepowered.api.entity.projectile.arrow.Arrow;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
@@ -48,11 +51,12 @@ public abstract class InteractiveAimingItem implements InteractiveItem {
         }
         Projectile projectile = (Projectile) entity;
         ProjectileSource shooter = projectile.getShooter();
-        if(!(shooter instanceof Entity)) {
+        if(!(shooter instanceof Player)) {
             return;
         }
-        Entity entityShooter = (Entity) shooter;
-        if(entityShooter.getUniqueId().equals(holder.getUUID()) && arrowID == null) {
+        Player entityShooter = (Player) shooter;
+        HandType hand = ItemUtils.getMatchingHand(entityShooter, matchingItem());
+        if(hand != null && entityShooter.getUniqueId().equals(holder.getUUID()) && arrowID == null) {
             launched(projectile);
         }
     }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/AbstractSpellCaster.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/AbstractSpellCaster.java
@@ -1,5 +1,6 @@
 package net.akami.yggdrasil.api.spell;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -11,9 +12,11 @@ public abstract class AbstractSpellCaster extends SpellCaster {
         super.generator = loadGenerator();
         super.baseSequence = loadSequence();
         super.manaUsage = loadManaUsage();
+        super.locationRequiredTiers = loadLocationRequiredTiers();
     }
 
     protected abstract Supplier<Spell> loadGenerator();
     protected abstract List<ElementType> loadSequence();
     protected abstract BiFunction<Float, Integer, Float> loadManaUsage();
+    protected List<Integer> loadLocationRequiredTiers() { return Collections.emptyList(); }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/Spell.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/Spell.java
@@ -8,25 +8,25 @@ import org.spongepowered.api.entity.living.player.Player;
 
 import java.util.List;
 
-public interface Spell {
+public interface Spell<T extends SpellLauncher<T>> {
 
-    List<SpellTier> getTiers();
-    SpellLauncher getLauncher();
+    List<SpellTier<T>> getTiers();
+    T getLauncher();
 
-    default SpellTier getTier(int tier) {
+    default SpellTier<T> getTier(int tier) {
         return getTiers().get(tier);
     }
 
     default void cast(Player player, Vector3d location, int tier) {
-        SpellCreationData data = new SpellCreationData();
+        SpellCreationData<T> data = new SpellCreationData<>();
         data.setProperty("location", location);
 
         for(int i = 0; i < tier; i++) {
-            SpellTier spellTier = getTier(i);
+            SpellTier<T> spellTier = getTier(i);
             spellTier.definePreLaunchProperties(player, data);
         }
 
-        SpellLauncher launcher = this.getLauncher();
+        T launcher = this.getLauncher();
 
         if(data.isStorable()) {
             LaunchableSpellItem item = new LaunchableSpellItem(data.getItem(), data, launcher);

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCaster.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCaster.java
@@ -9,7 +9,7 @@ public class SpellCaster {
     protected Supplier<Spell> generator;
     protected BiFunction<Float, Integer, Float> manaUsage;
     protected List<ElementType> baseSequence;
-    private List<Integer> locationRequiredTiers = Collections.emptyList();
+    protected List<Integer> locationRequiredTiers = Collections.emptyList();
     private int currentMaxTier = 7;
 
     protected SpellCaster() { }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCreationData.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCreationData.java
@@ -12,7 +12,8 @@ import java.util.function.BiConsumer;
 
 public class SpellCreationData<T extends SpellLauncher> {
 
-    private List<BiConsumer<Player, T>> actions;
+    private List<BiConsumer<Player, T>> preActions;
+    private List<BiConsumer<Player, T>> postActions;
     private PropertyMap propertyMap;
 
     private boolean isStorable;
@@ -20,7 +21,8 @@ public class SpellCreationData<T extends SpellLauncher> {
     private InteractiveItemHandler handler;
 
     public SpellCreationData() {
-        this.actions = new ArrayList<>();
+        this.preActions = new ArrayList<>();
+        this.postActions = new ArrayList<>();
         this.propertyMap = new PropertyMap();
         this.isStorable = false;
     }
@@ -63,8 +65,12 @@ public class SpellCreationData<T extends SpellLauncher> {
         propertyMap.properties.put(name, value);
     }
 
-    public void addAction(BiConsumer<Player, T> action) {
-        actions.add(action);
+    public void addPreAction(BiConsumer<Player, T> action) {
+        preActions.add(action);
+    }
+
+    public void addPostAction(BiConsumer<Player, T> action) {
+        postActions.add(action);
     }
 
     public boolean isStorable() {
@@ -75,8 +81,16 @@ public class SpellCreationData<T extends SpellLauncher> {
         isStorable = storable;
     }
 
-    public void performActions(Player caster, T launcher) {
-        for(BiConsumer<Player, T> consumer : actions) {
+    public void performPreActions(Player caster, T launcher) {
+        performActions(caster, launcher, preActions);
+    }
+
+    public void performPostActions(Player caster, T launcher) {
+        performActions(caster, launcher, postActions);
+    }
+
+    private void performActions(Player caster, T launcher, Iterable<BiConsumer<Player, T>> sequence) {
+        for(BiConsumer<Player, T> consumer : sequence) {
             consumer.accept(caster, launcher);
         }
     }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCreationData.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellCreationData.java
@@ -38,7 +38,7 @@ public class SpellCreationData<T extends SpellLauncher> {
             if(result != null && type.isAssignableFrom(result.getClass())) {
                 return (R) result;
             }
-            throw new IllegalArgumentException("Property not found");
+            return null;
         }
 
         public <R> R getPropertyOrElse(String name, Class<R> type, R orElse) {

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellLauncher.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellLauncher.java
@@ -7,7 +7,8 @@ public interface SpellLauncher<SELF extends SpellLauncher<SELF>> {
     void commonLaunch(SpellCreationData<SELF> data, Player caster);
 
     default void launch(SpellCreationData<SELF> data, Player caster) {
+        data.performPreActions(caster, (SELF) this);
         commonLaunch(data, caster);
-        data.performActions(caster, (SELF) this);
+        data.performPostActions(caster, (SELF) this);
     }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellLauncher.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellLauncher.java
@@ -2,12 +2,12 @@ package net.akami.yggdrasil.api.spell;
 
 import org.spongepowered.api.entity.living.player.Player;
 
-public interface SpellLauncher {
+public interface SpellLauncher<SELF extends SpellLauncher<SELF>> {
 
-    void commonLaunch(SpellCreationData data, Player caster);
+    void commonLaunch(SpellCreationData<SELF> data, Player caster);
 
-    default void launch(SpellCreationData data, Player caster) {
+    default void launch(SpellCreationData<SELF> data, Player caster) {
         commonLaunch(data, caster);
-        data.performActions(caster);
+        data.performActions(caster, (SELF) this);
     }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/SpellTier.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/SpellTier.java
@@ -2,7 +2,7 @@ package net.akami.yggdrasil.api.spell;
 
 import org.spongepowered.api.entity.living.player.Player;
 
-public interface SpellTier {
+public interface SpellTier<T extends SpellLauncher> {
 
-    void definePreLaunchProperties(Player caster, SpellCreationData data);
+    void definePreLaunchProperties(Player caster, SpellCreationData<T> data);
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/utils/ItemUtils.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/utils/ItemUtils.java
@@ -36,8 +36,12 @@ public class ItemUtils {
 
     public static HandType getMatchingHand(Player target, ItemStack item) {
         Optional<ItemStack> optItem = target.getItemInHand(HandTypes.MAIN_HAND);
+        if(optItem.isPresent() && ItemStackComparators.IGNORE_SIZE.compare(optItem.get(), item) == 0) {
+            return HandTypes.MAIN_HAND;
+        }
+        optItem = target.getItemInHand(HandTypes.OFF_HAND);
         return optItem.isPresent() && ItemStackComparators.IGNORE_SIZE.compare(optItem.get(), item) == 0
-                ? HandTypes.MAIN_HAND
-                : HandTypes.OFF_HAND;
+                ? HandTypes.OFF_HAND
+                : null;
     }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/utils/ItemUtils.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/utils/ItemUtils.java
@@ -21,17 +21,23 @@ public class ItemUtils {
     }
 
     public static void fitItem(Player player, InteractiveItemHandler handler, InteractiveItem item) {
+        if(fitItemInInventory(player, item)) {
+            handler.addItem(item);
+        }
+    }
+
+    public static boolean fitItemInInventory(Player player, InteractiveItem item) {
         if(item == null) {
             throw new IllegalStateException("Cannot add null item to inventory");
         }
         ItemStack itemToProvide = item.matchingItem();
         for(Slot slot : player.getInventory().<Slot>slots()) {
-            if(slot.canFit(itemToProvide)) {
-                handler.addItem(item);
+            if(slot.size() == 0) {
                 slot.set(itemToProvide);
-                return;
+                return true;
             }
         }
+        return false;
     }
 
     public static HandType getMatchingHand(Player target, ItemStack item) {

--- a/api/src/main/java/net/akami/yggdrasil/api/utils/YggdrasilMath.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/utils/YggdrasilMath.java
@@ -18,6 +18,10 @@ public class YggdrasilMath {
         return new Vector3d(x, y/1.5, z);
     }
 
+    public static double velocityToFallingDistance(double yVelocity) {
+        return Math.max(2.8 * Math.exp(1.298 * Math.abs(yVelocity)) - 5, 0);
+    }
+
     public static BiFunction<Float, Integer, Float> instantCostFunction(Function<Integer, Float> costPerTier) {
         return (time, tier) -> time == 0 ? costPerTier.apply(tier) : 0f;
     }

--- a/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
@@ -76,7 +76,7 @@ public class AdvancedMovementItem implements InteractiveItem {
         target.setVelocity(this.nextDirection.mul(factor).add(targetVelocity).div(1, 1.4, 1));
         double yVelocity = - target.getVelocity().getY();
         if(!target.isOnGround()) {
-            target.offer(Keys.FALL_DISTANCE, (float) Math.max(2.8 * Math.exp(1.298 * yVelocity) - 5, 0));
+            target.offer(Keys.FALL_DISTANCE, (float) YggdrasilMath.velocityToFallingDistance(yVelocity));
         }
         this.nextDirection = null;
     }

--- a/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
@@ -67,7 +67,7 @@ public class AdvancedMovementItem implements InteractiveItem {
         } else {
             performJump(target, factor);
             changeItemColor(target, PotionTypes.SLOWNESS);
-            clock.queueItem(this, 60);
+            clock.queueItem(this, 300);
         }
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
+++ b/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
@@ -10,6 +10,7 @@ import net.akami.yggdrasil.item.*;
 import net.akami.yggdrasil.life.PlayerLifeComponent;
 import net.akami.yggdrasil.mana.PlayerManaContainer;
 import net.akami.yggdrasil.spell.FireballCaster;
+import net.akami.yggdrasil.spell.IncendiaCaster;
 import net.akami.yggdrasil.spell.PhoenixArrowCaster;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
@@ -83,6 +84,7 @@ public class YggdrasilPlayer implements AbstractYggdrasilPlayer {
 
         spells.add(new FireballCaster(this));
         spells.add(new PhoenixArrowCaster());
+        spells.add(new IncendiaCaster());
         /*spells.add(new SpellCaster.Builder()
                 .withGenerator(WindOfFireSpell::new)
                 .withManaUsage(YggdrasilMath.instantStandardPolynomialFunction(120))

--- a/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
+++ b/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
@@ -78,36 +78,12 @@ public class YggdrasilPlayer implements AbstractYggdrasilPlayer {
         return Optional.empty();
     }
 
-    // TODO : Don't hardcode values
     @Override
     public void addDefaultSpells() {
 
         spells.add(new FireballCaster(this));
         spells.add(new PhoenixArrowCaster());
         spells.add(new IncendiaCaster());
-        /*spells.add(new SpellCaster.Builder()
-                .withGenerator(WindOfFireSpell::new)
-                .withManaUsage(YggdrasilMath.instantStandardPolynomialFunction(120))
-                .withSequence(
-                        ElementType.FIRE, ElementType.FIRE, ElementType.FIRE,
-                        ElementType.EARTH,
-                        ElementType.AIR,
-                        ElementType.EARTH)
-                .build());
-        spells.add(new SpellCaster.Builder()
-                .withGenerator(EarthTowerSpell::new)
-                .withManaUsage(YggdrasilMath.instantStandardPolynomialFunction(40))
-                .withSequence(
-                        ElementType.EARTH, ElementType.EARTH, ElementType.EARTH,
-                        ElementType.AIR)
-                .build());
-        spells.add(new SpellCaster.Builder()
-                .withGenerator(GravitySpell::new)
-                .withManaUsage(YggdrasilMath.instantStandardPolynomialFunction(80))
-                .withSequence(
-                        ElementType.EARTH, ElementType.EARTH,
-                        ElementType.AIR, ElementType.AIR)
-                .build());*/
     }
 
     @Override

--- a/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
+++ b/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
@@ -10,6 +10,7 @@ import net.akami.yggdrasil.item.*;
 import net.akami.yggdrasil.life.PlayerLifeComponent;
 import net.akami.yggdrasil.mana.PlayerManaContainer;
 import net.akami.yggdrasil.spell.FireballCaster;
+import net.akami.yggdrasil.spell.PhoenixArrowCaster;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.ItemStack;
@@ -81,6 +82,7 @@ public class YggdrasilPlayer implements AbstractYggdrasilPlayer {
     public void addDefaultSpells() {
 
         spells.add(new FireballCaster(this));
+        spells.add(new PhoenixArrowCaster());
         /*spells.add(new SpellCaster.Builder()
                 .withGenerator(WindOfFireSpell::new)
                 .withManaUsage(YggdrasilMath.instantStandardPolynomialFunction(120))

--- a/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
+++ b/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
@@ -9,6 +9,7 @@ import net.akami.yggdrasil.api.spell.SpellCaster;
 import net.akami.yggdrasil.item.*;
 import net.akami.yggdrasil.life.PlayerLifeComponent;
 import net.akami.yggdrasil.mana.PlayerManaContainer;
+import net.akami.yggdrasil.spell.CounterVelocityCaster;
 import net.akami.yggdrasil.spell.FireballCaster;
 import net.akami.yggdrasil.spell.IncendiaCaster;
 import net.akami.yggdrasil.spell.PhoenixArrowCaster;
@@ -80,10 +81,12 @@ public class YggdrasilPlayer implements AbstractYggdrasilPlayer {
 
     @Override
     public void addDefaultSpells() {
-
-        spells.add(new FireballCaster(this));
-        spells.add(new PhoenixArrowCaster());
-        spells.add(new IncendiaCaster());
+        spells.addAll(Arrays.asList(
+                new FireballCaster(this),
+                new PhoenixArrowCaster(),
+                new IncendiaCaster(),
+                new CounterVelocityCaster(this)
+        ));
     }
 
     @Override

--- a/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
+++ b/core/src/main/java/net/akami/yggdrasil/player/YggdrasilPlayer.java
@@ -6,6 +6,7 @@ import net.akami.yggdrasil.api.mana.ManaContainer;
 import net.akami.yggdrasil.api.player.AbstractYggdrasilPlayer;
 import net.akami.yggdrasil.api.spell.ElementType;
 import net.akami.yggdrasil.api.spell.SpellCaster;
+import net.akami.yggdrasil.api.utils.ItemUtils;
 import net.akami.yggdrasil.item.*;
 import net.akami.yggdrasil.life.PlayerLifeComponent;
 import net.akami.yggdrasil.mana.PlayerManaContainer;
@@ -15,8 +16,6 @@ import net.akami.yggdrasil.spell.IncendiaCaster;
 import net.akami.yggdrasil.spell.PhoenixArrowCaster;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.item.inventory.ItemStack;
-import org.spongepowered.api.item.inventory.Slot;
 
 import java.util.*;
 
@@ -61,22 +60,9 @@ public class YggdrasilPlayer implements AbstractYggdrasilPlayer {
 
     private void fill(Player target) {
         target.getInventory().clear();
-        Iterator<Slot> slots = target.getInventory().<Slot>slots().iterator();
-        for(InteractiveItem interactiveItem : items) {
-            ItemStack item = interactiveItem.matchingItem();
-            Optional<Slot> freeSlot = findSlot(slots, item);
-            freeSlot.ifPresent((slot) -> slot.set(item));
+        for(InteractiveItem item : items) {
+            ItemUtils.fitItemInInventory(target, item);
         }
-    }
-
-    private Optional<Slot> findSlot(Iterator<Slot> slots, ItemStack item) {
-        while (slots.hasNext()) {
-            Slot current = slots.next();
-            if (current.canFit(item)) {
-                return Optional.of(current);
-            }
-        }
-        return Optional.empty();
     }
 
     @Override

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityCaster.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityCaster.java
@@ -1,0 +1,39 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.item.InteractiveItemHandler;
+import net.akami.yggdrasil.api.spell.AbstractSpellCaster;
+import net.akami.yggdrasil.api.spell.ElementType;
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.utils.YggdrasilMath;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+public class CounterVelocityCaster extends AbstractSpellCaster {
+
+    private InteractiveItemHandler handler;
+
+    public CounterVelocityCaster(InteractiveItemHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    protected Supplier<Spell> loadGenerator() {
+        return () -> new CounterVelocitySpell(handler);
+    }
+
+    @Override
+    protected List<ElementType> loadSequence() {
+        return Arrays.asList(
+                ElementType.AIR,
+                ElementType.AIR
+        );
+    }
+
+    @Override
+    protected BiFunction<Float, Integer, Float> loadManaUsage() {
+        return YggdrasilMath.instantStandardPolynomialFunction(10);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityLauncher.java
@@ -1,13 +1,32 @@
 package net.akami.yggdrasil.spell;
 
+import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellCreationData.PropertyMap;
 import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.utils.YggdrasilMath;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
 
 public class CounterVelocityLauncher implements SpellLauncher {
 
+    private Vector3d counteredVelocity;
+
     @Override
     public void commonLaunch(SpellCreationData data, Player caster) {
+        Vector3d currentVelocity = caster.getVelocity();
+        PropertyMap map = data.getPropertyMap();
+        double maxVelocityCountered = map.getProperty("max_velocity_countered", Double.class);
+        this.counteredVelocity = currentVelocity.length() <= maxVelocityCountered
+                ? currentVelocity
+                : currentVelocity.normalize().mul(maxVelocityCountered);
 
+        caster.setVelocity(currentVelocity.sub(counteredVelocity));
+        float fakeFallingDistance = (float) YggdrasilMath.velocityToFallingDistance(caster.getVelocity().getY());
+        caster.offer(Keys.FALL_DISTANCE, fakeFallingDistance);
+    }
+
+    public Vector3d getCounteredVelocity() {
+        return counteredVelocity;
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityLauncher.java
@@ -1,0 +1,13 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class CounterVelocityLauncher implements SpellLauncher {
+
+    @Override
+    public void commonLaunch(SpellCreationData data, Player caster) {
+
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityMaxTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityMaxTier.java
@@ -1,0 +1,19 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class CounterVelocityMaxTier implements SpellTier {
+
+    private double maxVelocityCountered;
+
+    public CounterVelocityMaxTier(double maxVelocityCountered) {
+        this.maxVelocityCountered = maxVelocityCountered;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.setProperty("max_velocity_countered", maxVelocityCountered);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityPushBackTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocityPushBackTier.java
@@ -1,0 +1,53 @@
+package net.akami.yggdrasil.spell;
+
+import com.flowpowered.math.vector.Vector3d;
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.effect.particle.ParticleEffect;
+import org.spongepowered.api.effect.particle.ParticleTypes;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class CounterVelocityPushBackTier implements SpellTier<CounterVelocityLauncher> {
+
+    private ParticleEffect effect;
+
+    public CounterVelocityPushBackTier() {
+        this.effect = ParticleEffect.builder()
+                .type(ParticleTypes.CLOUD)
+                .quantity(50)
+                .offset(new Vector3d(1.5,1.5,1.5))
+                .build();
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData<CounterVelocityLauncher> data) {
+        data.addPostAction(this::pushEntities);
+    }
+
+    private void pushEntities(Player player, CounterVelocityLauncher launcher) {
+
+        spawnParticles(player);
+        double counteredVel = launcher.getCounteredVelocity().length();
+        Vector3d playerPos = player.getPosition();
+
+        for(Entity nearEntity : player.getNearbyEntities(15)) {
+
+            Vector3d direction = nearEntity.getLocation().getPosition().sub(playerPos);
+            double distance = direction.length();
+            if(distance == 0) {
+                continue;
+            }
+            direction = direction
+                    .normalize()
+                    .div(distance / 2)
+                    .mul(6 * counteredVel)
+                    .add(0, 0.4, 0);
+            nearEntity.setVelocity(nearEntity.getVelocity().add(direction));
+        }
+    }
+
+    private void spawnParticles(Player player) {
+        player.spawnParticles(effect, player.getPosition());
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
@@ -24,13 +24,13 @@ public class CounterVelocitySpell implements Spell {
     @Override
     public List<SpellTier> getTiers() {
         return Arrays.asList(
-                new CounterVelocityMaxTier(2),
-                new CounterVelocityMaxTier(2.5),
-                new CounterVelocityMaxTier(3),
-                new StorableSpellTier(item, handler, 1),
-                new CounterVelocityMaxTier(3.5),
+                new CounterVelocityMaxTier(1),
+                new CounterVelocityMaxTier(1.6),
+                new CounterVelocityMaxTier(2.2),
                 new CounterVelocityPushBackTier(),
-                new StorableSpellTier(2)
+                new CounterVelocityMaxTier(2.6),
+                new StorableSpellTier(item, handler, 2),
+                new StorableSpellTier(3)
         );
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
@@ -1,16 +1,37 @@
 package net.akami.yggdrasil.spell;
 
+import net.akami.yggdrasil.api.item.InteractiveItemHandler;
 import net.akami.yggdrasil.api.spell.Spell;
 import net.akami.yggdrasil.api.spell.SpellLauncher;
 import net.akami.yggdrasil.api.spell.SpellTier;
+import net.akami.yggdrasil.api.spell.StorableSpellTier;
+import org.spongepowered.api.item.ItemTypes;
+import org.spongepowered.api.item.inventory.ItemStack;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class CounterVelocitySpell implements Spell {
 
+    private InteractiveItemHandler handler;
+    private ItemStack item;
+
+    public CounterVelocitySpell(InteractiveItemHandler handler) {
+        this.handler = handler;
+        this.item = ItemStack.of(ItemTypes.FEATHER);
+    }
+
     @Override
     public List<SpellTier> getTiers() {
-        return null;
+        return Arrays.asList(
+                new CounterVelocityMaxTier(2),
+                new CounterVelocityMaxTier(2.5),
+                new CounterVelocityMaxTier(3),
+                new StorableSpellTier(item, handler, 1),
+                new CounterVelocityMaxTier(3.5),
+                new CounterVelocityPushBackTier(),
+                new StorableSpellTier(2)
+        );
     }
 
     @Override

--- a/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/CounterVelocitySpell.java
@@ -1,0 +1,20 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.spell.SpellTier;
+
+import java.util.List;
+
+public class CounterVelocitySpell implements Spell {
+
+    @Override
+    public List<SpellTier> getTiers() {
+        return null;
+    }
+
+    @Override
+    public SpellLauncher getLauncher() {
+        return new CounterVelocityLauncher();
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/FireballSpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/FireballSpell.java
@@ -29,7 +29,7 @@ public class FireballSpell implements Spell {
                 new FireballDamageTier(2, 3),
                 new FireballDamageTier(2, 4),
                 new StorableSpellTier(fireBall, handler, 1),
-                new FireballDamageTier(2, 4),
+                new FireballDamageTier(2, 4.5),
                 new StorableSpellTier(2),
                 new StorableSpellTier(3));
     }

--- a/core/src/main/java/net/akami/yggdrasil/spell/FireballSpellLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/FireballSpellLauncher.java
@@ -19,8 +19,9 @@ public class FireballSpellLauncher implements SpellLauncher {
 
         Entity fireBall = createBaseEntity(caster);
 
-        int radius = data.getProperty("radius", Integer.class);
-        double damage = data.getProperty("damage", Double.class);
+        SpellCreationData.PropertyMap propertyMap = data.getPropertyMap();
+        int radius = propertyMap.getProperty("radius", Integer.class);
+        double damage = propertyMap.getProperty("damage", Double.class);
         fireBall.offer(Keys.EXPLOSION_RADIUS, Optional.of(radius));
         fireBall.offer(Keys.ATTACK_DAMAGE, damage);
     }

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCaster.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCaster.java
@@ -1,0 +1,37 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.AbstractSpellCaster;
+import net.akami.yggdrasil.api.spell.ElementType;
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.utils.YggdrasilMath;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+public class IncendiaCaster extends AbstractSpellCaster {
+
+    @Override
+    protected Supplier<Spell> loadGenerator() {
+        return IncendiaSpell::new;
+    }
+
+    @Override
+    protected List<ElementType> loadSequence() {
+        return Arrays.asList(
+                ElementType.FIRE,
+                ElementType.FIRE
+        );
+    }
+
+    @Override
+    protected BiFunction<Float, Integer, Float> loadManaUsage() {
+        return YggdrasilMath.instantStandardPolynomialFunction(30);
+    }
+
+    @Override
+    protected List<Integer> loadLocationRequiredTiers() {
+        return Arrays.asList(1,2,3,4,5,6,7);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCaster.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCaster.java
@@ -21,7 +21,8 @@ public class IncendiaCaster extends AbstractSpellCaster {
     protected List<ElementType> loadSequence() {
         return Arrays.asList(
                 ElementType.FIRE,
-                ElementType.FIRE
+                ElementType.FIRE,
+                ElementType.AIR
         );
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCraterTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCraterTier.java
@@ -1,12 +1,57 @@
 package net.akami.yggdrasil.spell;
 
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
 import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellCreationData.PropertyMap;
 import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.world.World;
 
-public class IncendiaCraterTier implements SpellTier {
+import java.util.Random;
+
+public class IncendiaCraterTier implements SpellTier<IncendiaSpellLauncher> {
+
+    private SpellCreationData<IncendiaSpellLauncher> data;
+
     @Override
-    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+    public void definePreLaunchProperties(Player caster, SpellCreationData<IncendiaSpellLauncher> data) {
+        this.data = data;
+        data.addPreAction((futureCaster, launcher) -> makeCrater(futureCaster));
+        //data.setProperty("explosion_radius", 0); // For testing only
+    }
 
+    private void makeCrater(Player caster) {
+        PropertyMap map = data.getPropertyMap();
+        Vector3d arrowLocation = map.getProperty("location", Vector3d.class);
+        int radius = map.getProperty("radius", Integer.class);
+        World world = caster.getWorld();
+        Random random = new Random();
+
+        for(int dx = -radius; dx <= radius; dx++) {
+            for(int dz = -radius; dz <= radius; dz++) {
+                createHole(random, arrowLocation, world, dx, dz, radius);
+            }
+        }
+    }
+
+    private void createHole(Random random, Vector3d arrowLocation, World world, int dx, int dz, int radius) {
+        double distance = Math.sqrt(dx*dx + dz*dz);
+        if(distance == 0) distance = 1;
+        int depth = (int) (2 * (random.nextDouble()/2 + 0.6) * (radius/(1.5 * distance)));
+        int count = 0;
+        int currentDeltaY = radius;
+        while(count < depth && currentDeltaY >= -radius) {
+            currentDeltaY--;
+            Vector3i pos = new Vector3i(
+                    arrowLocation.getFloorX() + dx,
+                    arrowLocation.getFloorY() + currentDeltaY,
+                    arrowLocation.getFloorZ() + dz);
+            if(world.getBlockType(pos) != BlockTypes.AIR) {
+                count++;
+                world.setBlockType(pos, BlockTypes.AIR);
+            }
+        }
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCraterTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaCraterTier.java
@@ -1,0 +1,12 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class IncendiaCraterTier implements SpellTier {
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaExplosionTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaExplosionTier.java
@@ -1,0 +1,19 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class IncendiaExplosionTier implements SpellTier {
+
+    private int radius;
+
+    public IncendiaExplosionTier(int radius) {
+        this.radius = radius;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.setProperty("explosion_radius", radius);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaRadiusTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaRadiusTier.java
@@ -1,0 +1,19 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class IncendiaRadiusTier implements SpellTier {
+
+    private int radius;
+
+    public IncendiaRadiusTier(int radius) {
+        this.radius = radius;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.setProperty("radius", radius);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpell.java
@@ -1,0 +1,29 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.spell.SpellTier;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IncendiaSpell implements Spell {
+
+    @Override
+    public List<SpellTier> getTiers() {
+        return Arrays.asList(
+                new IncendiaRadiusTier(3),
+                new IncendiaRadiusTier(4),
+                new IncendiaRadiusTier(5),
+                new IncendiaExplosionTier(2),
+                new IncendiaRadiusTier(6),
+                new IncendiaExplosionTier(4),
+                new IncendiaCraterTier()
+        );
+    }
+
+    @Override
+    public SpellLauncher getLauncher() {
+        return new IncendiaSpellLauncher();
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpellLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpellLauncher.java
@@ -33,20 +33,20 @@ public class IncendiaSpellLauncher implements SpellLauncher {
             createExplosion(world, explosionRadius, center);
         }
         Task.builder()
-                .delay(700, TimeUnit.MILLISECONDS)
+                .delay(250, TimeUnit.MILLISECONDS)
                 .execute(() -> createFireArea(world, fireRadius, center))
                 .submit(Sponge.getPluginManager().getPlugin("yggdrasil").get());
     }
 
     private void createFireArea(World world, int radius, Vector3d center) {
         Random random = new Random();
-        for(int x = -radius; x <= radius; x++) {
-            for(int y = -5; y <= 5; y++) {
-                for (int z = -radius; z <= radius; z++) {
+        for(int dx = -radius; dx <= radius; dx++) {
+            for(int dy = -10; dy <= 5; dy++) {
+                for (int dz = -radius; dz <= radius; dz++) {
                     Vector3i fireLoc = new Vector3i(
-                            center.getFloorX() + x,
-                            center.getFloorY() + y,
-                            center.getFloorZ() + z);
+                            center.getFloorX() + dx,
+                            center.getFloorY() + dy,
+                            center.getFloorZ() + dz);
                     if(world.getBlockType(fireLoc) == BlockTypes.AIR && random.nextFloat() < 0.6) {
                         world.setBlockType(fireLoc, BlockTypes.FIRE);
                     }

--- a/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpellLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/IncendiaSpellLauncher.java
@@ -1,0 +1,64 @@
+package net.akami.yggdrasil.spell;
+
+import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellCreationData.PropertyMap;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.world.World;
+
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class IncendiaSpellLauncher implements SpellLauncher {
+
+    @Override
+    public void commonLaunch(SpellCreationData data, Player caster) {
+
+        PropertyMap map = data.getPropertyMap();
+        Vector3d center = map.getProperty("location", Vector3d.class);
+        int fireRadius = map.getProperty("radius", Integer.class);
+        int explosionRadius = map.getPropertyOrElse("explosion_radius", Integer.class, 0);
+        World world = caster.getWorld();
+
+        if(explosionRadius != 0) {
+            createExplosion(world, explosionRadius, center);
+        }
+        Task.builder()
+                .delay(700, TimeUnit.MILLISECONDS)
+                .execute(() -> createFireArea(world, fireRadius, center))
+                .submit(Sponge.getPluginManager().getPlugin("yggdrasil").get());
+    }
+
+    private void createFireArea(World world, int radius, Vector3d center) {
+        Random random = new Random();
+        for(int x = -radius; x <= radius; x++) {
+            for(int y = -5; y <= 5; y++) {
+                for (int z = -radius; z <= radius; z++) {
+                    Vector3i fireLoc = new Vector3i(
+                            center.getFloorX() + x,
+                            center.getFloorY() + y,
+                            center.getFloorZ() + z);
+                    if(world.getBlockType(fireLoc) == BlockTypes.AIR && random.nextFloat() < 0.6) {
+                        world.setBlockType(fireLoc, BlockTypes.FIRE);
+                    }
+                }
+            }
+        }
+    }
+
+    private void createExplosion(World world, int radius, Vector3d center) {
+        Explosive tnt = (Explosive) world.createEntity(EntityTypes.PRIMED_TNT, center);
+        tnt.offer(Keys.EXPLOSION_RADIUS, Optional.of(radius));
+        world.spawnEntity(tnt);
+        tnt.detonate();
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowBaseTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowBaseTier.java
@@ -1,0 +1,58 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.effect.particle.ParticleEffect;
+import org.spongepowered.api.effect.particle.ParticleTypes;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.world.World;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class PhoenixArrowBaseTier implements SpellTier<PhoenixArrowLauncher> {
+
+    private World world;
+    private ParticleEffect effect;
+
+    public PhoenixArrowBaseTier() {
+        this.effect = ParticleEffect.builder()
+                .type(ParticleTypes.FLAME)
+                .quantity(1)
+                .build();
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
+        data.setProperty("damage", 2.0);
+        data.addAction(this::addParticles);
+    }
+
+    private void addParticles(Player player, PhoenixArrowLauncher launcher) {
+        this.world = player.getWorld();
+        Task.builder()
+                .delay(100, TimeUnit.MILLISECONDS)
+                .interval(20, TimeUnit.MILLISECONDS)
+                .execute(task -> spawnParticles(task, launcher))
+                .submit(Sponge.getPluginManager().getPlugin("yggdrasil").get());
+    }
+
+    private void spawnParticles(Task task, PhoenixArrowLauncher launcher) {
+        List<Entity> entities = launcher.getAsEntities(world)
+                .stream()
+                .filter((e) -> e.getVelocity().length() > 0.1)
+                .collect(Collectors.toList());
+        if(entities.size() == 0) {
+            task.cancel();
+            return;
+        }
+
+        for(Entity arrow : entities) {
+            world.spawnParticles(effect, arrow.getLocation().getPosition());
+        }
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowBaseTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowBaseTier.java
@@ -29,7 +29,7 @@ public class PhoenixArrowBaseTier implements SpellTier<PhoenixArrowLauncher> {
     @Override
     public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
         data.setProperty("damage", 2.0);
-        data.addAction(this::addParticles);
+        data.addPostAction(this::addParticles);
     }
 
     private void addParticles(Player player, PhoenixArrowLauncher launcher) {

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCaster.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCaster.java
@@ -22,7 +22,7 @@ public class PhoenixArrowCaster extends AbstractSpellCaster {
         return Arrays.asList(
                 ElementType.FIRE,
                 ElementType.AIR,
-                ElementType.EARTH
+                ElementType.AIR
         );
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCaster.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCaster.java
@@ -1,0 +1,33 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.AbstractSpellCaster;
+import net.akami.yggdrasil.api.spell.ElementType;
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.utils.YggdrasilMath;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+public class PhoenixArrowCaster extends AbstractSpellCaster {
+
+    @Override
+    protected Supplier<Spell> loadGenerator() {
+        return PhoenixArrowSpell::new;
+    }
+
+    @Override
+    protected List<ElementType> loadSequence() {
+        return Arrays.asList(
+                ElementType.FIRE,
+                ElementType.AIR,
+                ElementType.EARTH
+        );
+    }
+
+    @Override
+    protected BiFunction<Float, Integer, Float> loadManaUsage() {
+        return YggdrasilMath.instantStandardPolynomialFunction(10);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCountTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowCountTier.java
@@ -1,0 +1,19 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class PhoenixArrowCountTier implements SpellTier<PhoenixArrowLauncher> {
+
+    private int count;
+
+    public PhoenixArrowCountTier(int count) {
+        this.count = count;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.setProperty("arrowsCount", count);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowDamageTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowDamageTier.java
@@ -1,0 +1,19 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class PhoenixArrowDamageTier implements SpellTier<PhoenixArrowLauncher> {
+
+    private double damage;
+
+    public PhoenixArrowDamageTier(double damage) {
+        this.damage = damage;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.setProperty("damage", damage);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowExplosiveTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowExplosiveTier.java
@@ -1,0 +1,13 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class PhoenixArrowExplosiveTier implements SpellTier<PhoenixArrowLauncher> {
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+        data.addProperty("explosive");
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -32,6 +32,11 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
         this.launcher = launcher;
         this.world = player.getWorld();
         this.playerTarget = findClosestPlayer(player);
+
+        if(playerTarget == null) {
+            return;
+        }
+
         Object plugin = Sponge.getPluginManager().getPlugin("yggdrasil").get();
         Task.builder()
                 .delay(500, TimeUnit.MILLISECONDS)
@@ -47,6 +52,9 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
 
         worldPlayers.forEach(entity -> distanceMap.put(entity, distance(entity, player)));
         List<Entry<Entity, Double>> orderedDistances = new ArrayList<>(distanceMap.entrySet());
+        if(orderedDistances.size() == 0) {
+            return null;
+        }
         orderedDistances.sort(Entry.comparingByValue());
         return orderedDistances
                 .get(0)

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -24,7 +24,7 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
 
     @Override
     public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
-        data.addAction(this::followEnemy);
+        data.addPostAction(this::followEnemy);
         data.setProperty("arrowsCount", 2);
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -26,7 +26,6 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
     @Override
     public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
         data.addAction(this::followEnemy);
-        data.setProperty("velocity_factor", 0.9);
         data.setProperty("arrowsCount", 2);
     }
 
@@ -37,7 +36,7 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
         Object plugin = Sponge.getPluginManager().getPlugin("yggdrasil").get();
         Task.builder()
                 .delay(500, TimeUnit.MILLISECONDS)
-                .interval(100, TimeUnit.MILLISECONDS)
+                .interval(200, TimeUnit.MILLISECONDS)
                 .execute(this::run)
                 .submit(plugin);
     }
@@ -71,11 +70,12 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
                 .map(Optional::get)
                 .collect(Collectors.toList());
         count++;
-        if (count >= 200 || arrows.isEmpty()) {
+        if (count >= 500 || arrows.isEmpty()) {
             task.cancel();
         }
         Optional<Entity> optPlayer = world.getEntity(playerTarget);
         if (!optPlayer.isPresent()) {
+            task.cancel();
             return;
         }
 
@@ -91,16 +91,14 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
         Vector3d arrowLocation = arrow.getLocation().getPosition();
         Vector3d currentVelocity = arrow.get(Keys.VELOCITY).orElse(Vector3d.ZERO);
 
-        double currentLength = currentVelocity.length();
-
         Vector3d direction = targetLocation
                 .sub(arrowLocation)
                 .normalize()
                 .add(currentVelocity.normalize().mul(1.7))
                 .normalize()
-                .mul(currentLength);
+                .mul(0.6);
 
         arrow.offer(Keys.VELOCITY, direction);
-        arrow.offer(Keys.ACCELERATION, direction.mul(0.005));
+        arrow.offer(Keys.ACCELERATION, direction.mul(0.0001));
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -14,7 +14,6 @@ import org.spongepowered.api.world.World;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher> {
 
@@ -63,12 +62,7 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
 
 
     private void run(Task task) {
-        List<Entity> arrows = launcher.arrows
-                .stream()
-                .map(world::getEntity)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toList());
+        List<Entity> arrows = launcher.getAsEntities(world);
         count++;
         if (count >= 500 || arrows.isEmpty()) {
             task.cancel();

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -26,7 +26,8 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
     @Override
     public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
         data.addAction(this::followEnemy);
-        data.setProperty("velocity_factor", 0.2);
+        data.setProperty("velocity_factor", 0.9);
+        data.setProperty("arrowsCount", 2);
     }
 
     private void followEnemy(Player player, PhoenixArrowLauncher launcher) {
@@ -70,7 +71,7 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
                 .map(Optional::get)
                 .collect(Collectors.toList());
         count++;
-        if (count >= 20 || arrows.isEmpty()) {
+        if (count >= 200 || arrows.isEmpty()) {
             task.cancel();
         }
         Optional<Entity> optPlayer = world.getEntity(playerTarget);
@@ -86,16 +87,20 @@ public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher>
     }
 
     private void redirect(Vector3d targetLocation, Entity arrow) {
-        System.out.println("Redirecting to aim : " + targetLocation);
+
         Vector3d arrowLocation = arrow.getLocation().getPosition();
         Vector3d currentVelocity = arrow.get(Keys.VELOCITY).orElse(Vector3d.ZERO);
+
+        double currentLength = currentVelocity.length();
+
         Vector3d direction = targetLocation
                 .sub(arrowLocation)
                 .normalize()
-                .mul(2)
-                ;//.add(currentVelocity.div(2));
+                .add(currentVelocity.normalize().mul(1.7))
+                .normalize()
+                .mul(currentLength);
 
         arrow.offer(Keys.VELOCITY, direction);
-        arrow.offer(Keys.ACCELERATION, direction.mul(0.0005));
+        arrow.offer(Keys.ACCELERATION, direction.mul(0.005));
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowGuidanceTier.java
@@ -1,0 +1,82 @@
+package net.akami.yggdrasil.spell;
+
+import com.flowpowered.math.vector.Vector3d;
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.world.World;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class PhoenixArrowGuidanceTier implements SpellTier<PhoenixArrowLauncher> {
+
+    private PhoenixArrowLauncher launcher;
+    private World world;
+    private UUID playerTarget;
+    private int count = 0;
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData<PhoenixArrowLauncher> data) {
+        data.addAction(this::followEnemy);
+    }
+
+    private void followEnemy(Player player, PhoenixArrowLauncher launcher) {
+        this.launcher = launcher;
+        this.world = player.getWorld();
+        this.playerTarget = findClosestPlayer(player);
+        Object plugin = Sponge.getPluginManager().getPlugin("yggdrasil").get();
+        Task.builder()
+                .interval(500, TimeUnit.MILLISECONDS)
+                .execute(this::run)
+                .submit(plugin);
+    }
+
+    private UUID findClosestPlayer(Player player) {
+
+        Collection<Player> worldPlayers = player.getWorld().getPlayers();
+        Map<Player, Double> distanceMap = new HashMap<>();
+
+        worldPlayers.forEach(entity -> distanceMap.put(entity, distance(entity, player)));
+        List<Entry<Player, Double>> orderedDistances = new ArrayList<>(distanceMap.entrySet());
+        orderedDistances.sort(Entry.comparingByValue());
+        return orderedDistances
+                .get(0)
+                .getKey()
+                .getUniqueId();
+    }
+
+    private double distance(Entity a, Entity b) {
+        Vector3d posA = a.getLocation().getPosition();
+        Vector3d posB = b.getLocation().getPosition();
+        return posA.distance(posB);
+    }
+
+
+    private void run(Task task) {
+        List<Entity> arrows = launcher.arrows
+                .stream()
+                .map(world::getEntity)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+        count++;
+        if(count >= 20 || arrows.isEmpty()) {
+            task.cancel();
+        }
+        Optional<Player> optPlayer = Sponge.getServer().getPlayer(playerTarget);
+        if(!optPlayer.isPresent()) {
+            return;
+        }
+
+        Player target = optPlayer.get();
+        for(Entity arrow : arrows) {
+            redirect(target, arrow);
+        }
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
@@ -88,11 +88,11 @@ public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher>
         Entity arrow = world.createEntity(EntityTypes.TIPPED_ARROW, arrowPosition);
         arrow.offer(Keys.HAS_GRAVITY, false);
 
-        double velocityFactor = map.getPropertyOrElse("velocity_factor", Double.class, 1.3d);
+        double velocityFactor = 1.3;
         Vector3d arrowDirection = dir.mul(velocityFactor);
 
         arrow.offer(Keys.VELOCITY, arrowDirection);
-        arrow.offer(Keys.ACCELERATION, arrowDirection.mul(0.0001));
+        arrow.offer(Keys.ACCELERATION, arrowDirection.mul(0.1));
         arrow.offer(Keys.FIRE_TICKS, 100000);
         arrow.offer(Keys.ATTACK_DAMAGE, map.getProperty("damage", Double.class));
         world.spawnEntity(arrow);

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
@@ -73,23 +73,29 @@ public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher>
         this.arrowsCount = map.getPropertyOrElse("arrowsCount", Integer.class, 1);
         Task.builder()
                 .interval(300, TimeUnit.MILLISECONDS)
-                .execute(task -> summonArrow(task, data, caster))
+                .execute(task -> summonArrow(task, map, caster))
                 .submit(plugin);
 
     }
 
-    private void summonArrow(Task task, SpellCreationData data, Player caster) {
+    private void summonArrow(Task task, PropertyMap map, Player caster) {
 
         Vector3d dir = YggdrasilMath.headRotationToDirection(caster.getHeadRotation());
-        Vector3d arrowPosition = caster.getPosition().add(dir.mul(2));
+        Vector3d arrowPosition = caster.getPosition()
+                .add(dir.mul(2))
+                .add(0, 1, 0);
         World world = caster.getWorld();
         Entity arrow = world.createEntity(EntityTypes.TIPPED_ARROW, arrowPosition);
-        arrow.offer(Keys.VELOCITY, dir.mul(2));
-        arrow.offer(Keys.ACCELERATION, dir.mul(0.05));
+        arrow.offer(Keys.HAS_GRAVITY, false);
+
+        double velocityFactor = map.getPropertyOrElse("velocity_factor", Double.class, 1d);
+        arrow.offer(Keys.VELOCITY, dir.mul(2 * velocityFactor));
+        arrow.offer(Keys.ACCELERATION, dir.mul(0.005));
         arrow.offer(Keys.FIRE_TICKS, 100000);
-        arrow.offer(Keys.ATTACK_DAMAGE, data.getPropertyMap().getProperty("damage", Double.class));
+        arrow.offer(Keys.ATTACK_DAMAGE, map.getProperty("damage", Double.class));
         world.spawnEntity(arrow);
         this.arrows.add(arrow.getUniqueId());
+        System.out.println("Added arrow : " + this.arrows);
 
         arrowsSummoned++;
         if(arrowsSummoned >= arrowsCount) {

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
@@ -1,0 +1,99 @@
+package net.akami.yggdrasil.spell;
+
+import com.flowpowered.math.vector.Vector3d;
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellCreationData.PropertyMap;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.utils.YggdrasilMath;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.data.key.Keys;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.explosive.Explosive;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.projectile.arrow.Arrow;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.action.CollideEvent;
+import org.spongepowered.api.event.entity.DestructEntityEvent;
+import org.spongepowered.api.event.filter.cause.First;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher> {
+
+    private int arrowsCount;
+    private int arrowsSummoned = 0;
+    List<UUID> arrows;
+
+    public PhoenixArrowLauncher() {
+        this.arrows = new ArrayList<>();
+    }
+
+    @Listener
+    public void onProjectileLanded(CollideEvent.Impact event, @First Arrow arrow) {
+
+        if(!arrows.remove(arrow.getUniqueId())) {
+            return;
+        }
+        World world = arrow.getWorld();
+        arrow.remove();
+        Explosive tnt = (Explosive) world.createEntity(EntityTypes.PRIMED_TNT, arrow.getLocation().getPosition());
+        world.spawnEntity(tnt);
+        tnt.detonate();
+
+        checkUnregistration();
+    }
+
+    @Listener
+    public void onProjectileKilled(DestructEntityEvent event) {
+        arrows.remove(event.getTargetEntity().getUniqueId());
+        checkUnregistration();
+    }
+
+    private void checkUnregistration() {
+        if(arrows.size() == 0) {
+            Sponge.getEventManager().unregisterListeners(this);
+        }
+    }
+
+    @Override
+    public void commonLaunch(SpellCreationData data, Player caster) {
+
+        Object plugin = Sponge.getPluginManager().getPlugin("yggdrasil").get();
+
+        if(data.hasProperty("explosive")) {
+            Sponge.getEventManager().registerListeners(plugin,this);
+        }
+        PropertyMap map = data.getPropertyMap();
+        this.arrowsCount = map.getPropertyOrElse("arrowsCount", Integer.class, 1);
+        Task.builder()
+                .interval(300, TimeUnit.MILLISECONDS)
+                .execute(task -> summonArrow(task, data, caster))
+                .submit(plugin);
+
+    }
+
+    private void summonArrow(Task task, SpellCreationData data, Player caster) {
+
+        Vector3d dir = YggdrasilMath.headRotationToDirection(caster.getHeadRotation());
+        Vector3d arrowPosition = caster.getPosition().add(dir.mul(2));
+        World world = caster.getWorld();
+        Entity arrow = world.createEntity(EntityTypes.TIPPED_ARROW, arrowPosition);
+        arrow.offer(Keys.VELOCITY, dir.mul(2));
+        arrow.offer(Keys.ACCELERATION, dir.mul(0.05));
+        arrow.offer(Keys.FIRE_TICKS, 100000);
+        arrow.offer(Keys.ATTACK_DAMAGE, data.getPropertyMap().getProperty("damage", Double.class));
+        world.spawnEntity(arrow);
+        this.arrows.add(arrow.getUniqueId());
+
+        arrowsSummoned++;
+        if(arrowsSummoned >= arrowsCount) {
+            task.cancel();
+        }
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
@@ -21,14 +21,16 @@ import org.spongepowered.api.world.World;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher> {
 
     private int arrowsCount;
     private int arrowsSummoned = 0;
-    List<UUID> arrows;
+    private List<UUID> arrows;
 
     public PhoenixArrowLauncher() {
         this.arrows = new ArrayList<>();
@@ -102,5 +104,14 @@ public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher>
         if(arrowsSummoned >= arrowsCount) {
             task.cancel();
         }
+    }
+
+    List<Entity> getAsEntities(World world) {
+        return arrows
+                .stream()
+                .map(world::getEntity)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowLauncher.java
@@ -88,14 +88,15 @@ public class PhoenixArrowLauncher implements SpellLauncher<PhoenixArrowLauncher>
         Entity arrow = world.createEntity(EntityTypes.TIPPED_ARROW, arrowPosition);
         arrow.offer(Keys.HAS_GRAVITY, false);
 
-        double velocityFactor = map.getPropertyOrElse("velocity_factor", Double.class, 1d);
-        arrow.offer(Keys.VELOCITY, dir.mul(2 * velocityFactor));
-        arrow.offer(Keys.ACCELERATION, dir.mul(0.005));
+        double velocityFactor = map.getPropertyOrElse("velocity_factor", Double.class, 1.3d);
+        Vector3d arrowDirection = dir.mul(velocityFactor);
+
+        arrow.offer(Keys.VELOCITY, arrowDirection);
+        arrow.offer(Keys.ACCELERATION, arrowDirection.mul(0.0001));
         arrow.offer(Keys.FIRE_TICKS, 100000);
         arrow.offer(Keys.ATTACK_DAMAGE, map.getProperty("damage", Double.class));
         world.spawnEntity(arrow);
         this.arrows.add(arrow.getUniqueId());
-        System.out.println("Added arrow : " + this.arrows);
 
         arrowsSummoned++;
         if(arrowsSummoned >= arrowsCount) {

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowSpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowSpell.java
@@ -10,7 +10,7 @@ public class PhoenixArrowSpell implements Spell<PhoenixArrowLauncher> {
     @Override
     public List<SpellTier<PhoenixArrowLauncher>> getTiers() {
         return Arrays.asList(
-                new PhoenixArrowDamageTier(2),
+                new PhoenixArrowBaseTier(),
                 new PhoenixArrowDamageTier(3),
                 new PhoenixArrowCountTier(2),
                 new PhoenixArrowExplosiveTier(),

--- a/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowSpell.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/PhoenixArrowSpell.java
@@ -1,0 +1,27 @@
+package net.akami.yggdrasil.spell;
+import net.akami.yggdrasil.api.spell.Spell;
+import net.akami.yggdrasil.api.spell.SpellTier;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class PhoenixArrowSpell implements Spell<PhoenixArrowLauncher> {
+
+    @Override
+    public List<SpellTier<PhoenixArrowLauncher>> getTiers() {
+        return Arrays.asList(
+                new PhoenixArrowDamageTier(2),
+                new PhoenixArrowDamageTier(3),
+                new PhoenixArrowCountTier(2),
+                new PhoenixArrowExplosiveTier(),
+                new PhoenixArrowCountTier(3),
+                new PhoenixArrowDamageTier(5),
+                new PhoenixArrowGuidanceTier()
+        );
+    }
+
+    @Override
+    public PhoenixArrowLauncher getLauncher() {
+        return new PhoenixArrowLauncher();
+    }
+}


### PR DESCRIPTION
This merge brings 2 kinds of changes:

- New spells, being:
    - Phoenix Arrows
    - Incendia
    - Counterspeed propulsion

- Minor changes in the API, such as the possibility for an abstract spell caster to define which tiers require aiming, as well as genericity in the spell system, so that the SpellCreationData can "know" which launcher it's working with. A static `PropertyMap` class has been added so that even with untyped SpellCreationData objects, the user is allowed to use generic methods, such as `getProperty`. `SpellTier`s can know define **pre** actions, to perform **before** launching the spell.