### PR TITLE
Api changes

### DIFF
--- a/api/src/main/java/net/akami/yggdrasil/api/data/BoolData.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/data/BoolData.java
@@ -1,0 +1,20 @@
+package net.akami.yggdrasil.api.data;
+
+import org.spongepowered.api.data.manipulator.DataManipulator;
+import org.spongepowered.api.data.manipulator.DataManipulatorBuilder;
+import org.spongepowered.api.data.manipulator.ImmutableDataManipulator;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+public interface BoolData extends DataManipulator<BoolData, BoolData.Immutable> {
+
+    Value<Boolean> enabled();
+
+    interface Immutable extends ImmutableDataManipulator<Immutable, BoolData> {
+        ImmutableValue<Boolean> enabled();
+    }
+
+    interface Builder extends DataManipulatorBuilder<BoolData, BoolData.Immutable> {
+
+    }
+}

--- a/api/src/main/java/net/akami/yggdrasil/api/data/PersistentData.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/data/PersistentData.java
@@ -1,0 +1,140 @@
+package net.akami.yggdrasil.api.data;
+
+import org.spongepowered.api.data.DataContainer;
+import org.spongepowered.api.data.DataHolder;
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.DataView;
+import org.spongepowered.api.data.manipulator.immutable.common.AbstractImmutableBooleanData;
+import org.spongepowered.api.data.manipulator.mutable.common.AbstractBooleanData;
+import org.spongepowered.api.data.merge.MergeFunction;
+import org.spongepowered.api.data.persistence.AbstractDataBuilder;
+import org.spongepowered.api.data.persistence.DataContentUpdater;
+import org.spongepowered.api.data.persistence.InvalidDataException;
+import org.spongepowered.api.data.value.immutable.ImmutableValue;
+import org.spongepowered.api.data.value.mutable.Value;
+
+import java.util.Optional;
+
+// Example of specific singular data
+// Example of API-implementation split
+// Example of data updating
+public class PersistentData extends AbstractBooleanData<BoolData, BoolData.Immutable> implements BoolData {
+    PersistentData(boolean enabled) {
+        super(enabled, YggdrasilKeys.PERSISTENT, false);
+    }
+
+    @Override
+    public Value<Boolean> enabled() {
+        return getValueGetter();
+    }
+
+    @Override
+    public Optional<BoolData> fill(DataHolder dataHolder, MergeFunction overlap) {
+        Optional<PersistentData> data_ = dataHolder.get(PersistentData.class);
+        if(data_.isPresent()) {
+            PersistentData data = data_.get();
+            PersistentData finalData = overlap.merge(this, data);
+            setValue(finalData.getValue());
+        }
+        return Optional.of(this);
+    }
+
+    @Override
+    public Optional<BoolData> from(DataContainer container) {
+        return from((DataView) container);
+    }
+
+    public Optional<BoolData> from(DataView view) {
+        if(view.contains(YggdrasilKeys.PERSISTENT.getQuery())) {
+            setValue(view.getBoolean(YggdrasilKeys.PERSISTENT.getQuery()).get());
+            return Optional.of(this);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public PersistentData copy() {
+        return new PersistentData(getValue());
+    }
+
+    @Override
+    public Immutable asImmutable() {
+        return new Immutable(getValue());
+    }
+
+    @Override
+    public int getContentVersion() {
+        return 2;
+    }
+
+    @Override
+    public DataContainer toContainer() {
+        return super.toContainer().set(YggdrasilKeys.PERSISTENT.getQuery(), getValue());
+    }
+
+    public static class Immutable extends AbstractImmutableBooleanData<BoolData.Immutable, BoolData> implements BoolData.Immutable {
+        Immutable(boolean enabled) {
+            super(enabled, YggdrasilKeys.PERSISTENT, false);
+        }
+
+        @Override
+        public PersistentData asMutable() {
+            return new PersistentData(getValue());
+        }
+
+        @Override
+        public int getContentVersion() {
+            return 2;
+        }
+
+        @Override
+        public DataContainer toContainer() {
+            return super.toContainer().set(YggdrasilKeys.PERSISTENT.getQuery(), getValue());
+        }
+
+        @Override
+        public ImmutableValue<Boolean> enabled() {
+            return getValueGetter();
+        }
+    }
+
+    public static class Builder extends AbstractDataBuilder<BoolData> implements BoolData.Builder {
+        Builder() {
+            super(BoolData.class, 2);
+        }
+
+        @Override
+        public PersistentData create() {
+            return new PersistentData(false);
+        }
+
+        @Override
+        public Optional<BoolData> createFrom(DataHolder dataHolder) {
+            return create().fill(dataHolder);
+        }
+
+        @Override
+        protected Optional<BoolData> buildContent(DataView container) throws InvalidDataException {
+            return create().from(container);
+        }
+    }
+
+    public static class BoolEnabled1To2Updater implements DataContentUpdater {
+
+        @Override
+        public int getInputVersion() {
+            return 1;
+        }
+
+        @Override
+        public int getOutputVersion() {
+            return 2;
+        }
+
+        @Override
+        public DataView update(DataView content) {
+            return content.set(DataQuery.of('.', "persistent.enabled"), content.get(DataQuery.of('.', "persistent.isEnabled"))).remove(DataQuery.of('.', "persistent.isEnabled"));
+        }
+    }
+}

--- a/api/src/main/java/net/akami/yggdrasil/api/data/YggdrasilData.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/data/YggdrasilData.java
@@ -1,0 +1,16 @@
+package net.akami.yggdrasil.api.data;
+
+import org.spongepowered.api.data.DataRegistration;
+
+public class YggdrasilData {
+
+    public static final DataRegistration<BoolData, BoolData.Immutable> PERSISTENT = DataRegistration.builder()
+            .name("Is Persistent")
+            .id("persistent")
+            .dataClass(BoolData.class)
+            .dataImplementation(PersistentData.class)
+            .immutableClass(BoolData.Immutable.class)
+            .immutableImplementation(PersistentData.Immutable.class)
+            .builder(new PersistentData.Builder())
+            .build();
+}

--- a/api/src/main/java/net/akami/yggdrasil/api/data/YggdrasilKeys.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/data/YggdrasilKeys.java
@@ -1,4 +1,4 @@
-package net.akami.yggdrasil.api.utils;
+package net.akami.yggdrasil.api.data;
 
 import org.spongepowered.api.data.DataQuery;
 import org.spongepowered.api.data.key.Key;
@@ -9,8 +9,8 @@ public class YggdrasilKeys {
 
     public static final Key<Value<Boolean>> PERSISTENT = Key.builder()
             .type(TypeTokens.BOOLEAN_VALUE_TOKEN)
-            .id("yggrasil:persistent")
+            .id("persistent")
             .name("Is Persistent")
-            .query(DataQuery.of('.', "bool.enabled"))
+            .query(DataQuery.of('.', "persistent.enabled"))
             .build();
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/game/events/CancelledEventsListener.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/game/events/CancelledEventsListener.java
@@ -1,5 +1,6 @@
 package net.akami.yggdrasil.api.game.events;
 
+import net.akami.yggdrasil.api.data.YggdrasilKeys;
 import net.akami.yggdrasil.api.player.AbstractYggdrasilPlayerManager;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Entity;
@@ -64,9 +65,9 @@ public class CancelledEventsListener {
 
     @Listener(order = Order.LAST)
     public void onItemSpawned(SpawnEntityEvent event) {
-        /*event.getEntities().stream()
+        event.getEntities().stream()
                 .filter(entity -> entity.getType() == EntityTypes.ITEM && !entity.get(YggdrasilKeys.PERSISTENT).orElse(false))
-        .forEach(Entity::remove);*/
+                .forEach(Entity::remove);
     }
     // TODO : add hit, craft, use anvils, enchantment tables
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/game/events/CancelledEventsListener.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/game/events/CancelledEventsListener.java
@@ -55,7 +55,6 @@ public class CancelledEventsListener {
         event
                 .filterEntities(entity -> entity.getType() != EntityTypes.EXPERIENCE_ORB)
                 .forEach(Entity::remove);
-
     }
 
     @Listener(order = Order.LAST)
@@ -65,9 +64,9 @@ public class CancelledEventsListener {
 
     @Listener(order = Order.LAST)
     public void onItemSpawned(SpawnEntityEvent event) {
-        event.
-                filterEntities(entity -> entity.getType() != EntityTypes.ITEM)
-                .forEach(Entity::remove);
+        /*event.getEntities().stream()
+                .filter(entity -> entity.getType() == EntityTypes.ITEM && !entity.get(YggdrasilKeys.PERSISTENT).orElse(false))
+        .forEach(Entity::remove);*/
     }
     // TODO : add hit, craft, use anvils, enchantment tables
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/input/CancellableEvent.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/input/CancellableEvent.java
@@ -1,0 +1,54 @@
+package net.akami.yggdrasil.api.input;
+
+import org.spongepowered.api.event.Cancellable;
+import org.spongepowered.api.event.Event;
+import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.EventContext;
+import org.spongepowered.api.util.annotation.eventgen.AbsoluteSortPosition;
+import org.spongepowered.api.util.annotation.eventgen.PropertySettings;
+
+public class CancellableEvent<T extends Cancellable & Event> implements Event, Cancellable {
+
+    private T event;
+
+    private CancellableEvent(T event) {
+        this.event = event;
+    }
+
+    public static <T extends Cancellable & Event> CancellableEvent<T> of(T event) {
+        return new CancellableEvent<>(event);
+    }
+
+    public T getEvent() {
+        return event;
+    }
+
+    @Override
+    @PropertySettings(requiredParameter = false)
+    public boolean isCancelled() {
+        return event.isCancelled();
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        event.setCancelled(cancel);
+    }
+
+    @Override
+    @AbsoluteSortPosition(0)
+    public Cause getCause() {
+        return event.getCause();
+    }
+
+    @Override
+    @PropertySettings(requiredParameter = false, generateMethods = false)
+    public Object getSource() {
+        return event.getSource();
+    }
+
+    @Override
+    @PropertySettings(requiredParameter = false, generateMethods = false)
+    public EventContext getContext() {
+        return event.getContext();
+    }
+}

--- a/api/src/main/java/net/akami/yggdrasil/api/input/ItemInteractionsListener.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/input/ItemInteractionsListener.java
@@ -5,7 +5,9 @@ import net.akami.yggdrasil.api.item.InteractiveItemHandler;
 import net.akami.yggdrasil.api.item.InteractiveItemUser;
 import org.spongepowered.api.block.BlockTypes;
 import org.spongepowered.api.data.type.HandTypes;
+import org.spongepowered.api.data.value.mutable.Value;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.entity.living.player.gamemode.GameModes;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.Listener;
@@ -54,10 +56,16 @@ public class ItemInteractionsListener {
 
     @Listener
     public void onChangeBlock(ChangeBlockEvent.Place event) {
-        getItem(event).ifPresent(item -> getHandler(event).ifPresent(handler -> {
-            handler.rightClick(item, CancellableEvent.of(event), clock);
-            if(event.getCause().first(Player.class).map(player -> player.gameMode().get() != GameModes.CREATIVE).orElse(false)) {
-                event.getTransactions().forEach(transaction -> transaction.setValid(false));
+        getItem(event).ifPresent(item -> getHandler(event).ifPresent(handler -> { //If item and handler are present
+
+            handler.rightClick(item, CancellableEvent.of(event), clock); //Trigger rightClick
+
+            Value<GameMode> playerMode = event.getCause()
+                    .first(Player.class)
+                    .map(Player::gameMode).get();
+
+            if(playerMode.get() != GameModes.CREATIVE) { //If the Player mode isn't CREATIVE
+                event.getTransactions().forEach(transaction -> transaction.setValid(false)); //Could be better. This also cancels item changes.
             }
         }));
     }

--- a/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveAimingItem.java
@@ -2,6 +2,7 @@ package net.akami.yggdrasil.api.item;
 
 import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.game.task.GameItemClock;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import net.akami.yggdrasil.api.input.UUIDHolder;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Entity;
@@ -11,7 +12,6 @@ import org.spongepowered.api.entity.projectile.arrow.Arrow;
 import org.spongepowered.api.entity.projectile.source.ProjectileSource;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.action.CollideEvent;
-import org.spongepowered.api.event.action.InteractEvent;
 import org.spongepowered.api.event.entity.DestructEntityEvent;
 import org.spongepowered.api.event.entity.SpawnEntityEvent;
 import org.spongepowered.api.event.filter.cause.First;
@@ -83,7 +83,7 @@ public abstract class InteractiveAimingItem implements InteractiveItem {
     }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
 
         if(arrowID == null || world == null) {
             return;
@@ -111,5 +111,6 @@ public abstract class InteractiveAimingItem implements InteractiveItem {
     }
 
     @Override
-    public void onLeftClicked(InteractEvent event, GameItemClock clock) { }
+    public void onLeftClicked(CancellableEvent<?> event, GameItemClock clock) {
+    }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveItem.java
@@ -1,16 +1,21 @@
 package net.akami.yggdrasil.api.item;
 
 import net.akami.yggdrasil.api.game.task.GameItemClock;
-import org.spongepowered.api.event.action.InteractEvent;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 public interface InteractiveItem {
 
     ItemStack matchingItem();
 
-    void onLeftClicked(InteractEvent event, GameItemClock clock);
-    void onRightClicked(InteractEvent event, GameItemClock clock);
+    void onLeftClicked(CancellableEvent<?> event, GameItemClock clock);
 
-    default boolean isDestroyed() { return false; }
-    default void onReady(){}
+    void onRightClicked(CancellableEvent<?> event, GameItemClock clock);
+
+    default boolean isDestroyed() {
+        return false;
+    }
+
+    default void onReady() {
+    }
 }

--- a/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveItemHandler.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/InteractiveItemHandler.java
@@ -1,7 +1,7 @@
 package net.akami.yggdrasil.api.item;
 
 import net.akami.yggdrasil.api.game.task.GameItemClock;
-import org.spongepowered.api.event.action.InteractEvent;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.ItemStackComparators;
 
@@ -12,11 +12,11 @@ public interface InteractiveItemHandler {
 
     List<InteractiveItem> getItems();
 
-    default void leftClick(ItemStack item, InteractEvent event, GameItemClock clock) {
+    default void leftClick(ItemStack item, CancellableEvent<?> event, GameItemClock clock) {
         click(item, (interactiveItem) -> interactiveItem.onLeftClicked(event, clock));
     }
 
-    default void rightClick(ItemStack item, InteractEvent event, GameItemClock clock) {
+    default void rightClick(ItemStack item, CancellableEvent<?> event, GameItemClock clock) {
         click(item, (interactiveItem) -> interactiveItem.onRightClicked(event, clock));
     }
 

--- a/api/src/main/java/net/akami/yggdrasil/api/item/LaunchableSpellItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/LaunchableSpellItem.java
@@ -1,12 +1,12 @@
 package net.akami.yggdrasil.api.item;
 
 import net.akami.yggdrasil.api.game.task.GameItemClock;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import net.akami.yggdrasil.api.spell.SpellCreationData;
 import net.akami.yggdrasil.api.spell.SpellLauncher;
 import net.akami.yggdrasil.api.utils.ItemUtils;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.action.InteractEvent;
 import org.spongepowered.api.item.inventory.ItemStack;
 
 public class LaunchableSpellItem implements InteractiveItem {
@@ -27,15 +27,20 @@ public class LaunchableSpellItem implements InteractiveItem {
     }
 
     @Override
-    public void onLeftClicked(InteractEvent event, GameItemClock clock) { }
+    public void onLeftClicked(CancellableEvent<?> event, GameItemClock clock) {
+    }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
         Player player = event.getCause().first(Player.class).get();
         HandType chosen = ItemUtils.getMatchingHand(player, this.modelItem);
 
         int nextQuantity = this.modelItem.getQuantity() - 1;
-        this.modelItem.setQuantity(nextQuantity);
+        if(nextQuantity <= 0) {
+            this.modelItem = ItemStack.empty();
+        } else {
+            this.modelItem.setQuantity(nextQuantity);
+        }
 
         player.setItemInHand(chosen, this.modelItem);
         launcher.launch(finalData, player);

--- a/api/src/main/java/net/akami/yggdrasil/api/item/LaunchableSpellItem.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/item/LaunchableSpellItem.java
@@ -2,6 +2,7 @@ package net.akami.yggdrasil.api.item;
 
 import net.akami.yggdrasil.api.game.task.GameItemClock;
 import net.akami.yggdrasil.api.input.CancellableEvent;
+import net.akami.yggdrasil.api.spell.MagicUser;
 import net.akami.yggdrasil.api.spell.SpellCreationData;
 import net.akami.yggdrasil.api.spell.SpellLauncher;
 import net.akami.yggdrasil.api.utils.ItemUtils;
@@ -14,11 +15,13 @@ public class LaunchableSpellItem implements InteractiveItem {
     private ItemStack modelItem;
     private SpellCreationData finalData;
     private SpellLauncher launcher;
+    private MagicUser user;
 
-    public LaunchableSpellItem(ItemStack item, SpellCreationData finalData, SpellLauncher launcher) {
+    public LaunchableSpellItem(ItemStack item, SpellCreationData finalData, SpellLauncher launcher, MagicUser user) {
         this.modelItem = item;
         this.finalData = finalData;
         this.launcher = launcher;
+        this.user = user;
     }
 
     @Override
@@ -36,14 +39,10 @@ public class LaunchableSpellItem implements InteractiveItem {
         HandType chosen = ItemUtils.getMatchingHand(player, this.modelItem);
 
         int nextQuantity = this.modelItem.getQuantity() - 1;
-        if(nextQuantity <= 0) {
-            this.modelItem = ItemStack.empty();
-        } else {
-            this.modelItem.setQuantity(nextQuantity);
-        }
+        this.modelItem.setQuantity(nextQuantity);
 
         player.setItemInHand(chosen, this.modelItem);
-        launcher.launch(finalData, player);
+        launcher.launch(finalData, player, user);
     }
 
     @Override

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/StorableSpellTier.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/StorableSpellTier.java
@@ -4,7 +4,7 @@ import net.akami.yggdrasil.api.item.InteractiveItemHandler;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.ItemStack;
 
-public class StorableSpellTier<T extends SpellLauncher<?>> implements SpellTier<T> {
+public class StorableSpellTier<T extends SpellLauncher<T>> implements SpellTier<T> {
 
     private ItemStack itemToProvide;
     private InteractiveItemHandler handler;

--- a/api/src/main/java/net/akami/yggdrasil/api/spell/StorableSpellTier.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/spell/StorableSpellTier.java
@@ -4,7 +4,7 @@ import net.akami.yggdrasil.api.item.InteractiveItemHandler;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.item.inventory.ItemStack;
 
-public class StorableSpellTier implements SpellTier {
+public class StorableSpellTier<T extends SpellLauncher<?>> implements SpellTier<T> {
 
     private ItemStack itemToProvide;
     private InteractiveItemHandler handler;
@@ -21,9 +21,9 @@ public class StorableSpellTier implements SpellTier {
     }
 
     @Override
-    public void definePreLaunchProperties(Player caster, SpellCreationData data) {
+    public void definePreLaunchProperties(Player caster, SpellCreationData<T> data) {
         data.setStorable(true);
-        if (itemToProvide != null && handler != null) {
+        if(itemToProvide != null && handler != null) {
             data.setItem(itemToProvide);
             data.setHandler(handler);
         }

--- a/api/src/main/java/net/akami/yggdrasil/api/utils/StructureBuilder.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/utils/StructureBuilder.java
@@ -1,0 +1,97 @@
+package net.akami.yggdrasil.api.utils;
+
+import org.spongepowered.api.block.BlockState;
+import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class StructureBuilder implements Consumer<Task> {
+
+    private List<List<List<BlockState>>> blocks;
+    private Location<World> startLocation;
+    private int speed;
+    private int currentX, currentY, currentZ = 0;
+    private Function<BlockState, SoundType> soundFunction;
+
+    public StructureBuilder(List<List<List<BlockState>>> blocks, Location<World> startLocation, int speed, Function<BlockState, SoundType> soundFunction) {
+        this.blocks = blocks;
+        this.startLocation = startLocation;
+        this.speed = speed;
+        this.soundFunction = soundFunction;
+    }
+
+    public StructureBuilder(List<List<List<BlockState>>> blocks, Location<World> startLocation, int speed) {
+        this(blocks, startLocation, speed, SOUND_PLACE);
+    }
+
+    @Override
+    public void accept(Task task) {
+        for(int i = 0; i < speed; i++) {
+
+            if(currentZ == blocks.get(currentX).get(currentY).size()) {
+                currentZ = 0;
+                currentY++;
+                if(currentY == blocks.get(currentX).size()) {
+                    currentY = 0;
+                    currentX++;
+                    if(currentX == blocks.size()) {
+                        task.cancel();
+                        return;
+                    }
+                }
+            }
+            BlockState blockState = blocks.get(currentX).get(currentY).get(currentZ);
+            currentZ++;
+            if(blockState.getType() == BlockTypes.AIR) continue;
+            startLocation.copy()
+                    .add(currentX, currentY, currentZ)
+                    .setBlock(blockState);
+            startLocation.getExtent().playSound(blockState.getType().getSoundGroup().getPlaceSound(), startLocation.getPosition(), 1);
+        }
+    }
+
+    public List<List<List<BlockState>>> getBlocks() {
+        return blocks;
+    }
+
+    public int getSpeed() {
+        return speed;
+    }
+
+    public int getCurrentX() {
+        return currentX;
+    }
+
+    public int getCurrentY() {
+        return currentY;
+    }
+
+    public int getCurrentZ() {
+        return currentZ;
+    }
+
+    public void setCurrentX(int currentX) {
+        this.currentX = currentX;
+    }
+
+    public void setCurrentY(int currentY) {
+        this.currentY = currentY;
+    }
+
+    public void setCurrentZ(int currentZ) {
+        this.currentZ = currentZ;
+    }
+
+    public void reset() {
+        currentX = currentY = currentZ = 0;
+    }
+
+    public static final Function<BlockState, SoundType> SOUND_PLACE = blockState -> blockState.getType().getSoundGroup().getPlaceSound();
+    public static final Function<BlockState, SoundType> SOUND_BREAK = blockState -> blockState.getType().getSoundGroup().getBreakSound();
+}

--- a/api/src/main/java/net/akami/yggdrasil/api/utils/YggdrasilKeys.java
+++ b/api/src/main/java/net/akami/yggdrasil/api/utils/YggdrasilKeys.java
@@ -1,0 +1,16 @@
+package net.akami.yggdrasil.api.utils;
+
+import org.spongepowered.api.data.DataQuery;
+import org.spongepowered.api.data.key.Key;
+import org.spongepowered.api.data.value.mutable.Value;
+import org.spongepowered.api.util.TypeTokens;
+
+public class YggdrasilKeys {
+
+    public static final Key<Value<Boolean>> PERSISTENT = Key.builder()
+            .type(TypeTokens.BOOLEAN_VALUE_TOKEN)
+            .id("yggrasil:persistent")
+            .name("Is Persistent")
+            .query(DataQuery.of('.', "bool.enabled"))
+            .build();
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,6 @@ subprojects {
 
     dependencies {
         testCompile group: 'junit', name: 'junit', version: '4.12'
-        compile 'org.spongepowered:spongeapi:7.2.0-SNAPSHOT'
+        compileOnly 'org.spongepowered:spongeapi:7.2.0-SNAPSHOT'
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,6 +6,7 @@ group 'net.akami.yggdrasil.core'
 
 dependencies {
     compile project(':api')
+    testCompile 'org.spongepowered:spongeapi:7.1.0'
 }
 
 jar {

--- a/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/AdvancedMovementItem.java
@@ -2,13 +2,13 @@ package net.akami.yggdrasil.item;
 
 import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.game.task.GameItemClock;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import net.akami.yggdrasil.api.item.InteractiveItem;
 import net.akami.yggdrasil.api.item.InteractiveItemUser;
 import net.akami.yggdrasil.api.utils.YggdrasilMath;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.action.InteractEvent;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.Slot;
@@ -47,22 +47,22 @@ public class AdvancedMovementItem implements InteractiveItem {
     }
 
     @Override
-    public void onLeftClicked(InteractEvent event, GameItemClock clock) {
+    public void onLeftClicked(CancellableEvent<?> event, GameItemClock clock) {
         clickPerformed(event, 1, clock);
     }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
         clickPerformed(event, 1.5, clock);
     }
 
-    private void clickPerformed(InteractEvent event, double factor, GameItemClock clock) {
+    private void clickPerformed(CancellableEvent<?> event, double factor, GameItemClock clock) {
         Player target = event.getCause().first(Player.class).get();
         double timeLeft = clock.timeLeft(this);
         if(timeLeft != 0) {
             return;
         }
-        if (nextDirection == null) {
+        if(nextDirection == null) {
             this.nextDirection = YggdrasilMath.headRotationToDirection(target.getHeadRotation());
         } else {
             performJump(target, factor);

--- a/core/src/main/java/net/akami/yggdrasil/item/ElementItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/ElementItem.java
@@ -14,7 +14,6 @@ import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.effect.particle.ParticleOptions;
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.action.InteractEvent;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.text.Text;
@@ -47,13 +46,13 @@ public abstract class ElementItem implements InteractiveItem {
     }
 
     @Override
-    public void onLeftClicked(InteractEvent event, GameItemClock clock) {
+    public void onLeftClicked(CancellableEvent<?> event, GameItemClock clock) {
         click();
         event.setCancelled(true);
     }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
 
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/item/InstantHealItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/InstantHealItem.java
@@ -2,6 +2,7 @@ package net.akami.yggdrasil.item;
 
 import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.game.task.GameItemClock;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import net.akami.yggdrasil.api.item.InteractiveItem;
 import net.akami.yggdrasil.api.life.LifeComponent;
 import net.akami.yggdrasil.api.life.LivingUser;
@@ -11,7 +12,6 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.effect.particle.ParticleEffect;
 import org.spongepowered.api.effect.particle.ParticleTypes;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.action.InteractEvent;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.inventory.ItemStack;
 
@@ -37,7 +37,7 @@ public class InstantHealItem implements InteractiveItem {
     }
 
     @Override
-    public void onLeftClicked(InteractEvent event, GameItemClock clock) {
+    public void onLeftClicked(CancellableEvent<?> event, GameItemClock clock) {
         LifeComponent component = livingUser.getLife();
         ManaContainer mana = manaHolder.getMana();
         int healValue = 5;
@@ -54,7 +54,7 @@ public class InstantHealItem implements InteractiveItem {
     }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
         event.setCancelled(true);
     }
 }

--- a/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
@@ -2,6 +2,7 @@ package net.akami.yggdrasil.item;
 
 import com.flowpowered.math.vector.Vector3d;
 import net.akami.yggdrasil.api.game.task.GameItemClock;
+import net.akami.yggdrasil.api.input.CancellableEvent;
 import net.akami.yggdrasil.api.item.InteractiveAimingItem;
 import net.akami.yggdrasil.api.spell.MagicUser;
 import net.akami.yggdrasil.api.spell.Spell;
@@ -10,7 +11,7 @@ import net.akami.yggdrasil.api.spell.SpellCaster;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.action.InteractEvent;
+import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.enchantment.EnchantmentTypes;
@@ -58,13 +59,13 @@ public class SpellTriggerItem extends InteractiveAimingItem {
     }
 
     @Override
-    public void onRightClicked(InteractEvent event, GameItemClock clock) {
+    public void onRightClicked(CancellableEvent<?> event, GameItemClock clock) {
         if(!aimlessSpell(event)) {
             super.onRightClicked(event, clock);
         }
     }
 
-    private boolean aimlessSpell(InteractEvent event) {
+    private boolean aimlessSpell(Cancellable event) {
 
         if(!ready) {
             return false;
@@ -73,7 +74,7 @@ public class SpellTriggerItem extends InteractiveAimingItem {
 
         if(optResult.isPresent()) {
             SpellCastContext result = optResult.get();
-            if (!result.requiresLocation()) {
+            if(!result.requiresLocation()) {
                 user.clearSequence();
                 applyEffect(null, result);
                 event.setCancelled(true);

--- a/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
@@ -8,10 +8,7 @@ import net.akami.yggdrasil.api.spell.MagicUser;
 import net.akami.yggdrasil.api.spell.Spell;
 import net.akami.yggdrasil.api.spell.SpellCastContext;
 import net.akami.yggdrasil.api.spell.SpellCaster;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.item.ItemTypes;
 import org.spongepowered.api.item.enchantment.Enchantment;
 import org.spongepowered.api.item.enchantment.EnchantmentTypes;
@@ -65,7 +62,7 @@ public class SpellTriggerItem extends InteractiveAimingItem {
         }
     }
 
-    private boolean aimlessSpell(Cancellable event) {
+    private boolean aimlessSpell(CancellableEvent<?> event) {
 
         if(!ready) {
             return false;
@@ -94,8 +91,7 @@ public class SpellTriggerItem extends InteractiveAimingItem {
     private void castSpell(SpellCaster caster, Vector3d location, int tier) {
         user.getMana().ifEnoughMana(caster.getCastingCost(tier), () -> {
             Spell spell = caster.createSpell();
-            Player wizard = Sponge.getServer().getPlayer(user.getUUID()).get();
-            spell.cast(wizard, location, tier);
+            spell.cast(user, location, tier);
         });
     }
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/SpellRadiusTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/SpellRadiusTier.java
@@ -5,7 +5,7 @@ import net.akami.yggdrasil.api.spell.SpellLauncher;
 import net.akami.yggdrasil.api.spell.SpellTier;
 import org.spongepowered.api.entity.living.player.Player;
 
-public class SpellRadiusTier<T extends SpellLauncher<?>> implements SpellTier<T> {
+public class SpellRadiusTier<T extends SpellLauncher<T>> implements SpellTier<T> {
 
     private int radius;
 

--- a/core/src/main/java/net/akami/yggdrasil/spell/SpellRadiusTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/SpellRadiusTier.java
@@ -1,0 +1,20 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class SpellRadiusTier<T extends SpellLauncher<?>> implements SpellTier<T> {
+
+    private int radius;
+
+    public SpellRadiusTier(int radius) {
+        this.radius = radius;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData<T> data) {
+        data.setProperty("radius", radius);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/SpellTimeTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/SpellTimeTier.java
@@ -1,0 +1,20 @@
+package net.akami.yggdrasil.spell;
+
+import net.akami.yggdrasil.api.spell.SpellCreationData;
+import net.akami.yggdrasil.api.spell.SpellLauncher;
+import net.akami.yggdrasil.api.spell.SpellTier;
+import org.spongepowered.api.entity.living.player.Player;
+
+public class SpellTimeTier<T extends SpellLauncher<?>> implements SpellTier<T> {
+
+    private long time;
+
+    public SpellTimeTier(long time) {
+        this.time = time;
+    }
+
+    @Override
+    public void definePreLaunchProperties(Player caster, SpellCreationData<T> data) {
+        data.setProperty("time", time);
+    }
+}

--- a/core/src/main/java/net/akami/yggdrasil/spell/SpellTimeTier.java
+++ b/core/src/main/java/net/akami/yggdrasil/spell/SpellTimeTier.java
@@ -5,7 +5,7 @@ import net.akami.yggdrasil.api.spell.SpellLauncher;
 import net.akami.yggdrasil.api.spell.SpellTier;
 import org.spongepowered.api.entity.living.player.Player;
 
-public class SpellTimeTier<T extends SpellLauncher<?>> implements SpellTier<T> {
+public class SpellTimeTier<T extends SpellLauncher<T>> implements SpellTier<T> {
 
     private long time;
 


### PR DESCRIPTION
# API Changes
- You can now use any Cancellable Event for InteractiveItem.
- Generified StorableSpellTier. You can now use raw type or a more generic type. It means spell which aren't using the generified StorableSpellTier AND spell using the generified version works.
- Added new PERSISTENT key allowing some items to not be removed by Yggdrasil