### PR TITLE
Fixed major issue: current sequence wouldn't be cleared in certain circumpstances

### DIFF
--- a/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
+++ b/core/src/main/java/net/akami/yggdrasil/item/SpellTriggerItem.java
@@ -54,7 +54,6 @@ public class SpellTriggerItem extends InteractiveAimingItem {
     @Override
     protected void applyEffect(Vector3d location, World world) {
         Optional<SpellCastContext> optResult = user.findBySequence();
-        user.clearSequence();
         optResult.ifPresent(result -> applyEffect(location, result));
     }
 
@@ -64,6 +63,7 @@ public class SpellTriggerItem extends InteractiveAimingItem {
         if(!aimlessSpell(event)) {
             super.onRightClicked(event, clock);
         }
+        user.clearSequence();
     }
 
     private boolean aimlessSpell(CancellableEvent<?> event) {
@@ -72,11 +72,9 @@ public class SpellTriggerItem extends InteractiveAimingItem {
             return false;
         }
         Optional<SpellCastContext> optResult = user.findBySequence();
-
         if(optResult.isPresent()) {
             SpellCastContext result = optResult.get();
             if(!result.requiresLocation()) {
-                user.clearSequence();
                 textDisplayer.clearActionBarDisplay();
                 applyEffect(null, result);
                 event.setCancelled(true);


### PR DESCRIPTION
Because of a mistake in the code, failing a sequence could potentially block the spell casting, since instead of just being reset when casting, it would persist, resulting in an endless chain of elements that could obviously never match any valid combination. This issue is now fixed.